### PR TITLE
Replace deprecated .dict() calls

### DIFF
--- a/backend/routers/automation.py
+++ b/backend/routers/automation.py
@@ -26,8 +26,8 @@ async def create_automation(
     user_id: str = Depends(get_user_id)
 ):
     """Создать новую автоматизацию"""
-    automation = Automation(**automation_data.dict(), user_id=user_id)
-    await db.automations.insert_one(automation.dict())
+    automation = Automation(**automation_data.model_dump(), user_id=user_id)
+    await db.automations.insert_one(automation.model_dump())
     return automation
 
 @router.get("/{automation_id}", response_model=Automation)
@@ -48,7 +48,7 @@ async def update_automation(
     user_id: str = Depends(get_user_id)
 ):
     """Обновить автоматизацию"""
-    update_dict = {k: v for k, v in update_data.dict().items() if v is not None}
+    update_dict = {k: v for k, v in update_data.model_dump().items() if v is not None}
     
     result = await db.automations.update_one(
         {"id": automation_id, "user_id": user_id},

--- a/backend/routers/integrations.py
+++ b/backend/routers/integrations.py
@@ -31,8 +31,8 @@ async def create_integration(
     user_id: str = Depends(get_user_id)
 ):
     """Создать новую интеграцию"""
-    integration = Integration(**integration_data.dict(), user_id=user_id)
-    await db.integrations.insert_one(integration.dict())
+    integration = Integration(**integration_data.model_dump(), user_id=user_id)
+    await db.integrations.insert_one(integration.model_dump())
     return integration
 
 @router.get("/{integration_id}", response_model=Integration)
@@ -53,7 +53,7 @@ async def update_integration(
     user_id: str = Depends(get_user_id)
 ):
     """Обновить интеграцию"""
-    update_dict = {k: v for k, v in update_data.dict().items() if v is not None}
+    update_dict = {k: v for k, v in update_data.model_dump().items() if v is not None}
     
     result = await db.integrations.update_one(
         {"id": integration_id, "user_id": user_id},

--- a/backend/services/client_service.py
+++ b/backend/services/client_service.py
@@ -8,8 +8,8 @@ class ClientService:
         self.collection = collection
 
     async def create_client(self, client_data: ClientCreate, user_id: str) -> Client:
-        client = Client(**client_data.dict(), user_id=user_id)
-        await self.collection.insert_one(client.dict())
+        client = Client(**client_data.model_dump(), user_id=user_id)
+        await self.collection.insert_one(client.model_dump())
         return client
 
     async def get_clients(self, user_id: str, status: Optional[ClientStatus] = None, 
@@ -30,7 +30,7 @@ class ClientService:
         return Client(**client) if client else None
 
     async def update_client(self, client_id: str, user_id: str, update_data: ClientUpdate) -> Optional[Client]:
-        update_dict = {k: v for k, v in update_data.dict().items() if v is not None}
+        update_dict = {k: v for k, v in update_data.model_dump().items() if v is not None}
         update_dict["updated_at"] = datetime.utcnow()
         
         result = await self.collection.update_one(

--- a/backend/services/message_service.py
+++ b/backend/services/message_service.py
@@ -8,8 +8,8 @@ class MessageService:
         self.collection = collection
 
     async def create_message(self, message_data: MessageCreate, user_id: str) -> Message:
-        message = Message(**message_data.dict(), user_id=user_id)
-        await self.collection.insert_one(message.dict())
+        message = Message(**message_data.model_dump(), user_id=user_id)
+        await self.collection.insert_one(message.model_dump())
         return message
 
     async def get_client_messages(self, client_id: str, user_id: str, limit: int = 100) -> List[Message]:


### PR DESCRIPTION
## Summary
- switch Pydantic model `.dict()` calls to `.model_dump()`
- keep compatibility with Pydantic v2

## Testing
- `pytest -q backend/tests/test_client_service.py`

------
https://chatgpt.com/codex/tasks/task_e_688cc89f7ab483308d16d075eebbcbee